### PR TITLE
Fix ref path is not correct in document snapshot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,6 @@ export const onCreate = <Model>(
   return firestore.document(path).onCreate(async (snap, ctx) => {
     const a = await adaptor()
     const data = wrapData(a, snap.data()) as Model
-
     return handler(doc(pathToRef(snap.ref.path), data), ctx)
   })
 }


### PR DESCRIPTION
The current implementation simply takes the collection path (for example, `/accounts/{accountId}/transactions` and the ID, to end up with a ref path of `/accounts/{accountId}/transactions/xxxxxxx`). 
This is correct for the trigger path, but it is **not** correct for the actual reference. It should end up as `/accounts/yyyyyyy/transactions/xxxxxxx`.


This commit fixes these issues and provides the correct path and it only affects subcollections.